### PR TITLE
Make `Benchmark.extend` support ES5 property descriptors.

### DIFF
--- a/_js/benchmark.src.js
+++ b/_js/benchmark.src.js
@@ -681,7 +681,19 @@
     delete arguments[0];
     forEach(arguments, function(source) {
       forProps(source, function(value, key) {
-        destination[key] = value;
+        try {
+          // in ES5 this could throw for inherited props
+          destination[key] = value;
+        } catch(e) {
+          // so in ES5 we can re-define them
+          // this might throw silently so ...
+          Object.defineProperty(destination, key, Object.create(null, {
+            enumerable: true,
+            writable: true,
+            configurable: true,
+            value: value
+          }));
+        }
       });
     });
     return destination;


### PR DESCRIPTION
Made `Benchmark.extend` more robust against ES5 property descriptors (i.e. a `set` throwing).
